### PR TITLE
iOS12.2 released

### DIFF
--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -90,8 +90,9 @@
           "status": "current"
         },
         "12.2": {
+          "release_date": "2019-03-25",
           "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_1_release_notes",
-          "status": "beta"
+          "status": "current"
         }
       }
     }


### PR DESCRIPTION
But Apple's release notes for Safari still not released for 12.2 even though there are changes. Date taken from https://developer.apple.com/news/releases/

I don't know if version 12 should be changed to "status" : "retired" or not.
